### PR TITLE
Move session data to session complete

### DIFF
--- a/api/session/complete.js
+++ b/api/session/complete.js
@@ -7,9 +7,14 @@ module.exports = async (req, res, ctx) => {
     }
 
     ctx.log.info(req.body, 'queueing session complete information')
+    const { seen, sessionId, packages, registry, language, metadata } = req.body
     await ctx.sqs.sendMessage({
-      seen: req.body.seen,
-      sessionId: req.body.sessionId,
+      seen,
+      sessionId,
+      packages,
+      registry,
+      language,
+      metadata,
       timestamp: Date.now()
     })
     res.status(200)

--- a/auth/index.js
+++ b/auth/index.js
@@ -231,17 +231,12 @@ Auth.prototype.validateApiKey = async function validateApiKey (key) {
 Auth.prototype.createAdSession = async function createSession (req) {
   // standard authorization header is `{ authorization: 'Bearer token' }`
   const apiKey = req.headers.authorization.split(' ').pop()
-  const { packages, language, registry, metadata } = req.body
   const sessionId = crypto.randomBytes(16).toString('hex')
   await this.docs.put({
     TableName: AdSessionTableName,
     Item: {
       sessionId,
       apiKey,
-      registry,
-      language,
-      packages,
-      metadata,
       created: Date.now()
     }
   }).promise()

--- a/schema/session/complete.js
+++ b/schema/session/complete.js
@@ -7,6 +7,19 @@ module.exports = {
         type: 'array',
         items: { type: 'string', maxLength: 128 }
       },
+      packages: {
+        type: 'array',
+        items: { type: 'string' }
+      },
+      registry: { type: 'string' },
+      language: { type: 'string' },
+      metadata: {
+        type: 'object',
+        properties: {
+          packageManagerVersion: { type: 'string' },
+          flossbankVersion: { type: 'string' }
+        }
+      },
       sessionId: { type: 'string' }
     }
   },

--- a/schema/session/start.js
+++ b/schema/session/start.js
@@ -1,23 +1,7 @@
 module.exports = {
   body: {
     type: 'object',
-    required: ['packages', 'language', 'registry'],
-    properties: {
-      packages: {
-        type: 'array',
-        items: { type: 'string' }
-      },
-      registry: { type: 'string' },
-      language: { type: 'string' },
-      metadata: {
-        type: 'object',
-        properties: {
-          packageManagerVersion: { type: 'string' },
-          flossbankVersion: { type: 'string' }
-        }
-      },
-      sessionId: { type: 'string' }
-    }
+    properties: { sessionId: { type: 'string' } }
   },
   response: {
     200: {

--- a/test/api/session/complete.test.js
+++ b/test/api/session/complete.test.js
@@ -22,7 +22,13 @@ test('POST `/session/complete` 401 unauthorized', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/complete',
-    payload: { seen: [], sessionId: 'session-id' },
+    payload: {
+      seen: [],
+      sessionId: 'session-id',
+      language: 'javascript',
+      registry: 'https://registry.npmjs.org/',
+      packages: ['yttrium-server@latest']
+    },
     headers: { authorization: 'not a valid token' }
   })
   t.deepEqual(res.statusCode, 401)
@@ -33,7 +39,7 @@ test('POST `/session/complete` 400 bad request', async (t) => {
   res = await t.context.app.inject({
     method: 'POST',
     url: '/session/complete',
-    payload: { sessionId: 'session-id' },
+    payload: { sessionId: 'session-id' }, // no seen
     headers: { authorization: 'valid-api-key' }
   })
   t.deepEqual(res.statusCode, 400)
@@ -41,7 +47,7 @@ test('POST `/session/complete` 400 bad request', async (t) => {
   res = await t.context.app.inject({
     method: 'POST',
     url: '/session/complete',
-    payload: { seen: [] },
+    payload: { seen: [] }, // no session id
     headers: { authorization: 'valid-api-key' }
   })
   t.deepEqual(res.statusCode, 400)
@@ -51,7 +57,13 @@ test('POST `/session/complete` 200 success', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/complete',
-    payload: { seen: [], sessionId: 'session-id' },
+    payload: {
+      seen: [],
+      sessionId: 'session-id',
+      language: 'javascript',
+      registry: 'https://registry.npmjs.org/',
+      packages: ['yttrium-server@latest']
+    },
     headers: { authorization: 'valid-api-key' }
   })
   t.deepEqual(res.statusCode, 200)
@@ -62,7 +74,13 @@ test('POST `/session/complete` 500 server error', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/complete',
-    payload: { seen: [], sessionId: 'session-id' },
+    payload: {
+      seen: [],
+      sessionId: 'session-id',
+      language: 'javascript',
+      registry: 'https://registry.npmjs.org/',
+      packages: ['yttrium-server@latest']
+    },
     headers: { authorization: 'valid-api-key' }
   })
   t.deepEqual(res.statusCode, 500)

--- a/test/api/session/start.test.js
+++ b/test/api/session/start.test.js
@@ -61,53 +61,16 @@ test('POST `/session/start` 401 unauthorized', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/start',
-    payload: {
-      language: 'javascript',
-      registry: 'https://registry.npmjs.org/',
-      packages: ['yttrium-server@latest']
-    }
-  })
-  t.deepEqual(res.statusCode, 401)
-})
-
-test('POST `/session/start` 400 bad request', async (t) => {
-  let res
-
-  res = await t.context.app.inject({
-    method: 'POST',
-    url: '/session/start',
     payload: {}
   })
-  t.deepEqual(res.statusCode, 400)
-
-  res = await t.context.app.inject({
-    method: 'POST',
-    url: '/session/start',
-    payload: {
-      registry: 'some url', packages: ['yttrium-server@latest']
-    }
-  })
-
-  res = await t.context.app.inject({
-    method: 'POST',
-    url: '/session/start',
-    payload: {
-      language: 'javascript',
-      packages: ['yttrium-server@latest']
-    }
-  })
-  t.deepEqual(res.statusCode, 400)
+  t.deepEqual(res.statusCode, 401)
 })
 
 test('POST `/session/start` 200 success', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/start',
-    payload: {
-      language: 'javascript',
-      registry: 'https://registry.npmjs.org/',
-      packages: ['yttrium-server@latest']
-    }
+    payload: {}
   })
   t.deepEqual(res.statusCode, 200)
   const payload = JSON.parse(res.payload)
@@ -127,11 +90,7 @@ test('POST `/session/start` 200 success | no ads no session', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/start',
-    payload: {
-      language: 'javascript',
-      registry: 'https://registry.npmjs.org/',
-      packages: ['yttrium-server@latest']
-    }
+    payload: {}
   })
   t.deepEqual(res.statusCode, 200)
   t.deepEqual(JSON.parse(res.payload), {
@@ -144,12 +103,7 @@ test('POST `/session/start` 200 success | existing session', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/start',
-    payload: {
-      language: 'javascript',
-      registry: 'https://registry.npmjs.org/',
-      packages: ['yttrium-server@latest'],
-      sessionId: 'existing-session-id'
-    }
+    payload: { sessionId: 'existing-session-id' }
   })
   t.deepEqual(res.statusCode, 200)
   const payload = JSON.parse(res.payload)
@@ -168,11 +122,7 @@ test('POST `/session/start` 500 server error', async (t) => {
   const res = await t.context.app.inject({
     method: 'POST',
     url: '/session/start',
-    payload: {
-      language: 'javascript',
-      registry: 'https://registry.npmjs.org/',
-      packages: ['yttrium-server@latest']
-    }
+    payload: {}
   })
   t.deepEqual(res.statusCode, 500)
 })

--- a/test/auth/index.test.js
+++ b/test/auth/index.test.js
@@ -336,12 +336,6 @@ test('createApiKey | success', async (t) => {
 
 test('createAdSession | creates and persists session', async (t) => {
   const sessionId = await t.context.auth.createAdSession({
-    body: {
-      packages: ['abc'],
-      registry: 'npm registry',
-      language: 'javascript',
-      metadata: { packageManagerVersion: 'papi@1.1.1' }
-    },
     headers: {
       authorization: 'bearer xyz'
     }
@@ -351,10 +345,6 @@ test('createAdSession | creates and persists session', async (t) => {
     Item: {
       sessionId: 'ff',
       apiKey: 'xyz',
-      registry: 'npm registry',
-      language: 'javascript',
-      packages: ['abc'],
-      metadata: { packageManagerVersion: 'papi@1.1.1' },
       created: 1234
     }
   }])


### PR DESCRIPTION
Moved session data to session complete; starting a session now requires no input (no 400 case) and session complete only requires a session id and seen array. Corresponds to https://github.com/flossbank/cli/pull/39