### PR TITLE
Disable non-error logging for health endpoint

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -82,8 +82,8 @@ const getUrl = require('../api/url/get')
 
 async function routes (fastify, opts, next) {
   // Health
-  fastify.get('/health', health)
-  fastify.post('/health', health)
+  fastify.get('/health', { logLevel: 'error' }, health)
+  fastify.post('/health', { logLevel: 'error' }, health)
 
   // Ad
   fastify.post('/ad/create', { preHandler: (req, res, done) => advertiserUIAuthMiddleware(req, res, fastify, done), schema: createAdSchema }, (req, res) => createAd(req, res, fastify))


### PR DESCRIPTION
Ref: https://www.fastify.io/docs/latest/Routes/#custom-log-level

Demo (b4 and after):
![health](https://user-images.githubusercontent.com/2707340/77237193-39a19500-6b83-11ea-86fd-4063b737e95e.gif)
