### PR TITLE
Use EFF wordlist instead of niceware for passphrases

### DIFF
--- a/api/user/complete-install.js
+++ b/api/user/complete-install.js
@@ -1,6 +1,14 @@
+const { INTEG_TEST_KEY } = require('../../helpers/constants')
+
 module.exports = async (req, res, ctx) => {
   try {
     const { token } = req.body
+
+    // this is safe because our integ test API key is public knowledge
+    if (token === INTEG_TEST_KEY) {
+      return res.send({ success: true, apiKey: INTEG_TEST_KEY })
+    }
+
     const apiKey = await ctx.auth.user.getInstallApiKey({ token })
     if (!apiKey) {
       res.status(401)

--- a/auth/index.js
+++ b/auth/index.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 const got = require('got')
 const FormData = require('form-data')
 const fastifyPlugin = require('fastify-plugin')
-const niceware = require('niceware')
+const niceware = require('eff-diceware-passphrase')
 
 const UserAuth = require('./user')
 const AdvertiserAuth = require('./advertiser')
@@ -64,7 +64,7 @@ class Auth {
 
   generateMagicLinkParams () {
     const token = this.generateRandomToken()
-    const code = this.niceware.generatePassphrase(4) // 2 words pls
+    const code = this.niceware(2) // 2 words pls
       .map(([first, ...rest]) => `${first.toUpperCase()}${rest.join('')}`) // title case pls
       .join(' ') // as a string pls
     return { token, code }

--- a/package-lock.json
+++ b/package-lock.json
@@ -988,10 +988,10 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
-    "binary-search": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
-      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    "binary-search-bounds": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
     },
     "bl": {
       "version": "1.2.2",
@@ -1042,6 +1042,37 @@
               "dev": true
             }
           }
+        }
+      }
+    },
+    "blake2b": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
+      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
+      "requires": {
+        "blake2b-wasm": "^1.1.0",
+        "nanoassert": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        }
+      }
+    },
+    "blake2b-wasm": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
+      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
+      "requires": {
+        "nanoassert": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
         }
       }
     },
@@ -2443,6 +2474,17 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
+      }
+    },
+    "eff-diceware-passphrase": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eff-diceware-passphrase/-/eff-diceware-passphrase-2.0.1.tgz",
+      "integrity": "sha512-OMjAg53/yQj+FeOBXqODsrZCrsz+Qw8lCmx+Z5UTaPekl0MQwIsn4ZmbMZpUjl1hPuDKlepnrikpICR2A7+Gyw==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
+        "nanoassert": "^2.0.0",
+        "secure-sample": "^1.0.2",
+        "secure-shuffle": "^1.1.0"
       }
     },
     "emittery": {
@@ -5306,6 +5348,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
+    "nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+    },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
@@ -5357,15 +5404,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "niceware": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/niceware/-/niceware-2.0.0.tgz",
-      "integrity": "sha512-BqxFABePNqGTJ/dk8W2C/qWixKuu5/xWYY0yPLCCgdIu6CYKXBh0NoUaYO+344WQTB9rffMMUEgcYl5KNCwuSw==",
-      "requires": {
-        "binary-search": "^1.3.3",
-        "randombytes": "^2.0.6"
-      }
-    },
     "nise": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
@@ -5415,7 +5453,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
       "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
-      "dev": true,
       "optional": true
     },
     "node-pre-gyp": {
@@ -6843,6 +6880,47 @@
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-1.0.0.tgz",
       "integrity": "sha512-kMg4jXttRQzVyLebIDc+MRxCueJ/zsmHpCn59BRd0mZUCd+V02wNd7/Pds8Nyhv7jfLHo1KkUOzdIF7cRMU4LQ=="
     },
+    "secure-random-uniform": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/secure-random-uniform/-/secure-random-uniform-3.1.0.tgz",
+      "integrity": "sha512-uRsCi2xIEhGx73ZW3k4OCIdEvN/N+Xk8GFPaFoYpguHoc2Qx1IZZGLmwM2eSmLShutyD9ve/lF0nx5MjGXbhmg==",
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "randombytes": "^2.0.3",
+        "sodium-universal": "^2.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        }
+      }
+    },
+    "secure-sample": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/secure-sample/-/secure-sample-1.0.3.tgz",
+      "integrity": "sha512-ps5Vij3/L8Pvak1sIYVyAWUIjcNCl3iLncOZB4KvtIzmVcsa+YK8lkHeABcf2+jDaZwvCqd9b7dUZR5xgLxF/w==",
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "secure-random-uniform": "^3.0.1"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        }
+      }
+    },
+    "secure-shuffle": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/secure-shuffle/-/secure-shuffle-1.2.0.tgz",
+      "integrity": "sha512-qQOYsWraLtuXecL8BzUFp9tWM6rF0+9rgsvFKsj4LF4yoBmQs7FSLGVlNfnBAZ7PPsQDB22X6oE6a6Sa7EEqgw==",
+      "requires": {
+        "secure-random-uniform": "^3.0.1"
+      }
+    },
     "seek-bzip": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
@@ -6942,6 +7020,21 @@
         "supports-color": "^5.5.0"
       }
     },
+    "siphash24": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz",
+      "integrity": "sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==",
+      "requires": {
+        "nanoassert": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6990,6 +7083,44 @@
             "es6-promisify": "^5.0.0"
           }
         }
+      }
+    },
+    "sodium-javascript": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.6.tgz",
+      "integrity": "sha512-Uk+JpqHEbzsEmiMxwL7TB/ndhMEpc52KdReYXXSIX2oRFPaI7ZDlDImF8KbkFWbYl9BJRtc82AZ/kNf4/0n9KA==",
+      "requires": {
+        "blake2b": "^2.1.1",
+        "nanoassert": "^1.0.0",
+        "siphash24": "^1.0.1",
+        "xsalsa20": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+          "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+        }
+      }
+    },
+    "sodium-native": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.9.tgz",
+      "integrity": "sha512-mbkiyA2clyfwAyOFIzMvsV6ny2KrKEIhFVASJxWfsmgfUEymgLIS2MLHHcGIQMkrcKhPErRaMR5Dzv0EEn+BWg==",
+      "optional": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "nan": "^2.14.0",
+        "node-gyp-build": "^4.1.0"
+      }
+    },
+    "sodium-universal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz",
+      "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
+      "requires": {
+        "sodium-javascript": "~0.5.0",
+        "sodium-native": "^2.0.0"
       }
     },
     "sonic-boom": {
@@ -8171,6 +8302,11 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "xsalsa20": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz",
+      "integrity": "sha512-zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "b36": "^1.0.0",
     "bcrypt": "^3.0.6",
     "dotenv": "^8.2.0",
+    "eff-diceware-passphrase": "^2.0.1",
     "fastify": "^2.10.0",
     "fastify-cookie": "^3.2.0",
     "fastify-cors": "^3.0.0",
@@ -37,7 +38,6 @@
     "got": "^9.6.0",
     "js-deep-equals": "^2.1.1",
     "mongodb": "^3.3.2",
-    "niceware": "^2.0.0",
     "rfc4648": "^1.3.0",
     "stripe": "^8.14.0",
     "ulid": "^2.3.0"

--- a/test/api/user/complete-install.test.js
+++ b/test/api/user/complete-install.test.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const { before, beforeEach, afterEach, after } = require('../../_helpers/_setup')
+const { INTEG_TEST_KEY } = require('../../../helpers/constants')
 
 test.before(async (t) => {
   await before(t, async ({ db, auth }) => {
@@ -32,6 +33,16 @@ test('POST `/user/complete-install` 401 unauthorized', async (t) => {
     payload: { token: 'not a valid token' }
   })
   t.deepEqual(res.statusCode, 401)
+})
+
+test('POST `/user/complete-install` integ test', async (t) => {
+  const res = await t.context.app.inject({
+    method: 'POST',
+    url: '/user/complete-install',
+    payload: { token: INTEG_TEST_KEY }
+  })
+  t.deepEqual(res.statusCode, 200)
+  t.deepEqual(JSON.parse(res.payload), { success: true, apiKey: INTEG_TEST_KEY })
 })
 
 test('POST `/user/complete-install` 400 bad request', async (t) => {


### PR DESCRIPTION
- Removed `niceware` in favor `eff-diceware-passphrase`. EFF released a wordlist that has no vulgar words and all of the words are demonstrably "well known". Bye yan 👋 
- Added a short circuit to `complete-install` for the integ tests.