### PR TITLE
Use magic wormhole style install tokens

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -62,6 +62,13 @@ class Auth {
     return crypto.randomBytes(32).toString('hex')
   }
 
+  // generates magic wormhole style tokens, e.g. 8-papa-champagne
+  generateEasyTokenString () {
+    const words = this.niceware(2)
+    const number = [...crypto.randomBytes(1)].pop()
+    return [number, ...words].join('-')
+  }
+
   generateMagicLinkParams () {
     const token = this.generateRandomToken()
     const code = this.niceware(2) // 2 words pls

--- a/auth/user.js
+++ b/auth/user.js
@@ -118,7 +118,7 @@ class UserAuthController {
 
   /* <install tokens> */
   async setInstallApiKey ({ apiKey }) {
-    const token = this.common.generateRandomToken()
+    const token = this.common.generateEasyTokenString()
     const expiration = this.common.getUnixTimestampPlus(this.constants.USER_INSTALL_TIMEOUT)
     await this.docs.put({
       TableName: this.constants.USER_INSTALL_TABLE,


### PR DESCRIPTION
inspired by [a tool i love using](https://magic-wormhole.readthedocs.io/en/latest/), i've switched the install tokens to #-word-word. i think this will be much easier to deal with (if we include the token in the curl line) or at least much less scary than what we had before.

it's of course not the same level of security as the original 32 byte token.