### PR TITLE
Update donation bugfixes

### DIFF
--- a/stripe/index.js
+++ b/stripe/index.js
@@ -67,9 +67,19 @@ class Stripe {
       return this.createDonation(customerId, amount)
     }
 
+    const existingPlanId = (customer.subscriptions.data[0].plan || {}).id
+    if (plan.id === existingPlanId) {
+      // donation amount is the same as what the user is already donating; nothing to do
+      return
+    }
+
+    const itemIdToUpdate = currentSubscription.items.data[0].id
     // Update the customers subscription to whichever plans
     await this.stripe.subscriptions.update(currentSubscription.id, {
-      items: [{ plan: plan.id }]
+      items: [{
+        id: itemIdToUpdate,
+        plan: plan.id
+      }]
     })
   }
 

--- a/test/stripe/index.test.js
+++ b/test/stripe/index.test.js
@@ -141,17 +141,41 @@ test('update donation | customer has one', async (t) => {
   stripe.stripe.customers.retrieve.resolves({
     subscriptions: {
       data: [
-        { id: 'sub-id' }
+        { id: 'sub-id', items: { data: [ { id: 'item-id' } ] } },
       ]
     }
   })
   await stripe.updateDonation('cust-id', 200)
   t.deepEqual(stripe.stripe.subscriptions.update.lastCall.args, [
     'sub-id',
-    { items: [{ plan: 2 }] }
+    { items: [{ id: 'item-id', plan: 2 }] }
   ])
 })
 
+test('update donation | customer has one and new amount is same as existing amount', async (t) => {
+  const { stripe } = t.context
+  stripe.stripe.customers.retrieve.resolves({
+    subscriptions: {
+      data: [
+        {
+          id: 'sub-id',
+          plan: {
+            id: 'plan-id-0',
+            amount: 40,
+          },
+          items: {
+            data: [
+              { id: 'item-id' }
+            ]
+          }
+        },
+      ]
+    }
+  })
+  stripe.findOrCreatePlan = () => ({ id: 'plan-id-0' })
+  await stripe.updateDonation('cust-id', 40)
+  t.true(stripe.stripe.subscriptions.update.notCalled)
+})
 test('delete donation | customer has one', async (t) => {
   const { stripe } = t.context
   stripe.stripe.customers.retrieve.resolves({


### PR DESCRIPTION
1. If new amount is same as existing amount, don't call Stripe
2. Properly re-use item.id in subscription update so that Stripe doesn't
   add additional donation