### PR TITLE
return 404 if no customer id in get donation info, not 500

### DIFF
--- a/api/organization/get-donation-info.js
+++ b/api/organization/get-donation-info.js
@@ -11,12 +11,10 @@ module.exports = async (req, res, ctx) => {
     ctx.log.info('fetching donation info for %s', organizationId)
     const org = await ctx.db.organization.get({ orgId: organizationId })
 
-    if (!org) {
+    if (!org || !org.billingInfo.customerId) {
       res.status(404)
       return res.send({ success: false })
     }
-
-    if (!org.billingInfo.customerId) throw new Error('No customer id for org when fetching donation info donation')
 
     const donationInfo = await ctx.stripe.getStripeCustomerDonationInfo({
       customerId: org.billingInfo.customerId

--- a/test/api/organization/get-donation-info.test.js
+++ b/test/api/organization/get-donation-info.test.js
@@ -138,7 +138,7 @@ test('GET `/organization/get-donation-info` 200 | donation not found but return 
   })
 })
 
-test('GET `/organization/get-donation-info` Error thrown when no customer id', async (t) => {
+test('GET `/organization/get-donation-info` 404 | no customer id', async (t) => {
   const res = await t.context.app.inject({
     method: 'GET',
     url: '/organization/get-donation-info',
@@ -147,7 +147,7 @@ test('GET `/organization/get-donation-info` Error thrown when no customer id', a
       cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.sessionWithoutCustomerId}`
     }
   })
-  t.deepEqual(res.statusCode, 500)
+  t.deepEqual(res.statusCode, 404)
 })
 
 test('GET `/organization/get-donation-info` 500 server error', async (t) => {


### PR DESCRIPTION
when org is first created, it doesn't have customerId until a donation is made. 

this fix ensures we don't throw an error when donation info is attempted to be fetched before a donation is made