### PR TITLE
NPM ownership initial impl

### DIFF
--- a/api/package/npm/ownership.js
+++ b/api/package/npm/ownership.js
@@ -1,0 +1,24 @@
+const { MSGS: { INTERNAL_SERVER_ERROR }, REGISTRIES: { NPM } } = require('../../../helpers/constants')
+
+module.exports = async (req, res, ctx) => {
+  try {
+    ctx.log.info('determining owned packages on NPM for maintainer: %s', req.session.userId)
+
+    const { readOnlyToken } = req.body
+
+    const username = await ctx.registry.npm.getUsername({ readOnlyToken })
+    await ctx.db.user.linkToRegistry({ userId: req.session.userId, registry: NPM, data: { username } })
+
+    ctx.log.info('%s has username %s on NPM', req.session.userId, username)
+
+    const packages = await ctx.registry.npm.getOwnedPackages({ username })
+    await ctx.db.package.refreshOwnership({ packages, registry: NPM, maintainerId: req.session.userId })
+    ctx.log.info('%s maintains %d packages on NPM', req.session.userId, packages.length)
+
+    res.send({ success: true })
+  } catch (e) {
+    ctx.log.error(e)
+    res.status(500)
+    res.send({ success: false, message: INTERNAL_SERVER_ERROR })
+  }
+}

--- a/api/package/npm/ownership.js
+++ b/api/package/npm/ownership.js
@@ -12,7 +12,7 @@ module.exports = async (req, res, ctx) => {
     ctx.log.info('%s has username %s on NPM', req.session.userId, username)
 
     const packages = await ctx.registry.npm.getOwnedPackages({ username })
-    await ctx.db.package.refreshOwnership({ packages, registry: NPM, maintainerId: req.session.userId })
+    await ctx.db.package.refreshOwnership({ packages, registry: NPM, userId: req.session.userId })
     ctx.log.info('%s maintains %d packages on NPM', req.session.userId, packages.length)
 
     res.send({ success: true })

--- a/db/package.js
+++ b/db/package.js
@@ -102,60 +102,74 @@ class PackageDbController {
   }
 
   async refreshOwnership ({ packages, registry, maintainerId }) {
+    // find all the packages in the DB that are marked as maintained by me,
+    // that are in the provided registry, and have a name that's in the list provided by the registry
     const existingPackages = await this.db.collection('packages').find({
       $or: [
         { name: { $in: packages } },
-        { owner: maintainerId }
+        { 'maintainers.maintainerId': maintainerId }
+        // https://docs.mongodb.com/manual/tutorial/query-array-of-documents/#specify-a-query-condition-on-a-field-in-an-array-of-documents
       ],
       registry
     }).toArray()
 
+    // of the packages already marked as maintained by me, whichever aren't in the list of
+    // packages provided, remove my id from their maintainers list
     const packageDeletions = existingPackages
       .filter(pkg => !packages.includes(pkg.name))
       .map(pkg => ({
         criteria: { name: pkg.name, registry },
         update: {
-          $set: { owner: null },
           $pull: { maintainers: { maintainerId } }
         }
       }))
+
+    // of the packages provided, whichever aren't already marked as maintained by me,
+    // push my id to their maintainers list (upsert if the package isn't in the DB at all)
     const packageInsertions = packages
       .filter(pkg => !existingPackages.some((ePkg) => ePkg.name === pkg))
       .map(pkg => ({
-        name: pkg,
-        registry,
-        owner: maintainerId,
-        maintainers: [{ maintainerId, revenuePercent: 100 }]
-      }))
-    const packageUpdates = existingPackages
-      .filter(pkg => pkg.owner !== maintainerId)
-      .map(pkg => {
-        const alreadyMaintains = pkg.maintainers.some(maintainer => maintainer.maintainerId === maintainerId)
-        return {
-          criteria: { name: pkg.name, registry },
-          update: {
-            $set: {
-              owner: maintainerId,
-              maintainers: alreadyMaintains
-                ? pkg.maintainers
-                : pkg.maintainers.concat([{ maintainerId, revenuePercent: 0 }])
-            }
+        criteria: {
+          name: pkg,
+          registry
+        },
+        update: {
+          $push: {
+            maintainers: { maintainerId, revenuePercent: 0 }
           }
         }
-      })
+      }))
+
     const bulkPackages = this.db.collection('packages').initializeUnorderedBulkOp()
 
     for (const insertion of packageInsertions) {
-      bulkPackages.insert(insertion)
-    }
-    for (const update of packageUpdates) {
-      bulkPackages.find(update.criteria).update(update.update)
+      bulkPackages.find(insertion.criteria).upsert().update(insertion.update)
     }
     for (const deletion of packageDeletions) {
       bulkPackages.find(deletion.criteria).update(deletion.update)
     }
 
+    // due to how the insertions/updates were done, there may be some packages that were upserted
+    // or updated and have only one maintainer with 0 percent revenue share. to fix that, we'll
+    // change those to 100%
+    bulkPackages.find({
+      registry,
+      maintainers: { $size: 1 }
+    }).update({
+      $set: {
+        'maintainers.$[].revenuePercent': 100
+        // https://docs.mongodb.com/manual/reference/operator/update/positional-all/#up._S_[]
+      }
+    })
+
     return bulkPackages.execute()
+  }
+
+  async getOwnedPackages ({ userId, registry }) {
+    return this.db.collection('packages').find({
+      'maintainers.maintainerId': userId,
+      registry
+    }).toArray()
   }
 }
 

--- a/db/user.js
+++ b/db/user.js
@@ -43,6 +43,16 @@ class UserDbController {
     })
   }
 
+  async linkToRegistry ({ userId, registry, data }) {
+    return this.db.collection('users').updateOne({
+      _id: ObjectId(userId)
+    }, {
+      $set: {
+        [registry]: data
+      }
+    })
+  }
+
   async get ({ userId }) {
     const user = await this.db.collection('users').findOne({ _id: ObjectId(userId) })
 

--- a/db/user.js
+++ b/db/user.js
@@ -43,6 +43,7 @@ class UserDbController {
     })
   }
 
+  // link registry-specific info to this user account (e.g. username on NPM)
   async linkToRegistry ({ userId, registry, data }) {
     return this.db.collection('users').updateOne({
       _id: ObjectId(userId)

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,4 +1,7 @@
 module.exports = {
+  REGISTRIES: {
+    NPM: 'npm'
+  },
   MSGS: {
     AD_NOT_CLEAN: 'String must be plain ASCII text. No Unicode, emojis, or control characters allowed.',
     ALREADY_EXISTS: 'An account with this email already exists',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4661,6 +4661,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -4940,6 +4946,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -5686,6 +5698,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "nock": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.5.tgz",
+      "integrity": "sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      }
     },
     "node-addon-api": {
       "version": "3.0.2",
@@ -6896,6 +6920,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@flossbank/schema": {
-      "version": "1.25.3",
-      "resolved": "https://registry.npmjs.org/@flossbank/schema/-/schema-1.25.3.tgz",
-      "integrity": "sha512-I3JrDh2WKXgTFWs/DRNw3svqcJwzEKfRB3nFFBzy3XN+vD1n4UdOGdMaV6Nc6/9Qi0vvjzljSmLrouPFYzh5mQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@flossbank/schema/-/schema-1.26.0.tgz",
+      "integrity": "sha512-Qo2QEh8BjKb45Sfd8nMdylvy2bArIEUqP1F++fV/yzW66NkRYf4Gsvf43644iVl9+k7OLXfvNXOc4Z7g/Ud5eQ==",
       "requires": {
         "fluent-schema": "^0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@flossbank/schema": "^1.25.3",
+    "@flossbank/schema": "^1.26.0",
     "@octokit/app": "^4.2.1",
     "ajv": "^6.10.2",
     "aws-sdk": "^2.543.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "husky": "^3.0.8",
     "mocdoc": "^2.0.0",
     "mongodb-memory-server": "^6.7.1",
+    "nock": "^13.0.5",
     "nyc": "^14.1.1",
     "pino-pretty": "^4.0.0",
     "sinon": "^7.5.0",

--- a/registry/index.js
+++ b/registry/index.js
@@ -1,13 +1,15 @@
 const fastifyPlugin = require('fastify-plugin')
 const NpmRegistry = require('./npm')
 
-function Registry () {
-  this.npm = new NpmRegistry()
-  this.supported = ['npm']
-}
+class Registry {
+  constructor () {
+    this.npm = new NpmRegistry()
+    this.supported = new Set(['npm'])
+  }
 
-Registry.prototype.isSupported = function isSupported (registry) {
-  return this.supported.includes(registry)
+  isSupported (registry) {
+    return this.supported.has(registry)
+  }
 }
 
 exports.Registry = Registry

--- a/registry/npm.js
+++ b/registry/npm.js
@@ -1,9 +1,31 @@
-const gop = require('get-owned-packages')
+const fetch = require('npm-registry-fetch')
 
-function NpmRegistry () {}
+class NpmRegistry {
+  constructor () {
+    this.constants = {
+      registry: 'https://registry.npmjs.org/',
+      readWrite: 'read-write',
+      write: 'write'
+    }
+  }
 
-NpmRegistry.prototype.getOwnedPackages = async function getOwnedPackages (token) {
-  return gop.getOwnedPackages(token)
+  async getUsername ({ readOnlyToken }) {
+    const opts = { registry: this.constants.registry, token: readOnlyToken }
+
+    // will throw in the case of an invalid token
+    const userData = await fetch.json('/-/npm/v1/user', opts)
+    const { name } = userData
+
+    return name
+  }
+
+  // returns list of package names that the provided username has read-write/write access to
+  async getOwnedPackages ({ username }) {
+    const packages = await fetch.json(`/-/org/${username}/package`)
+
+    const { readWrite, write } = this.constants
+    return Object.keys(packages).filter((pkg) => packages[pkg] === readWrite || packages[pkg] === write)
+  }
 }
 
 module.exports = NpmRegistry

--- a/routes/index.js
+++ b/routes/index.js
@@ -72,6 +72,7 @@ const updateOrg = require('../api/organization/update')
 // Packages
 const searchPackagesByName = require('../api/package/search-by-name')
 const getPackage = require('../api/package/get')
+const npmOwnership = require('../api/package/npm/ownership')
 // const refreshPackages = require('../api/package/refresh')
 // const updatePackages = require('../api/package/update')
 
@@ -176,6 +177,7 @@ async function routes (fastify, opts, done) {
   // Packages
   fastify.get('/package/search', { schema: Schema.package.searchByName }, (req, res) => searchPackagesByName(req, res, fastify))
   fastify.get('/package', { schema: Schema.package.get }, (req, res) => getPackage(req, res, fastify))
+  fastify.post('/package/npm/ownership', { schema: Schema.package.npm.ownership, preHandler: (req, res, done) => userWebMiddleware(req, res, fastify, done) }, (req, res) => npmOwnership(req, res, fastify))
   // fastify.post('/package/refresh', { preHandler: (req, res, done) => maintainerWebMiddleware(req, res, fastify, done), schema: Schema.package.refresh }, (req, res) => refreshPackages(req, res, fastify))
   // fastify.post('/package/update', { preHandler: (req, res, done) => maintainerWebMiddleware(req, res, fastify, done), schema: Schema.package.update }, (req, res) => updatePackages(req, res, fastify))
 

--- a/test/_helpers/_mocks.js
+++ b/test/_helpers/_mocks.js
@@ -17,7 +17,8 @@ module.exports = {
   },
   Registry: function Registry () {
     this.npm = {
-      getOwnedPackages: sinon.stub().resolves()
+      getUsername: sinon.stub().resolves('twoseventythree'),
+      getOwnedPackages: sinon.stub().resolves(['js-deep-equals', 'ninja-rmm-api'])
     }
     this.isSupported = sinon.stub().resolves(true)
   },

--- a/test/api/package/npm/ownership.test.js
+++ b/test/api/package/npm/ownership.test.js
@@ -1,0 +1,99 @@
+const test = require('ava')
+const { before, beforeEach, afterEach, after } = require('../../../_helpers/_setup')
+const { REGISTRIES: { NPM }, USER_WEB_SESSION_COOKIE } = require('../../../../helpers/constants')
+
+test.before(async (t) => {
+  await before(t, async ({ db, auth }) => {
+    const email = 'honey@etsy.com'
+    const { id: userId } = await db.user.create({ email })
+    t.context.userId = userId.toHexString()
+
+    const session = await auth.user.createWebSession({ userId: t.context.userId })
+    t.context.session = session.sessionId
+  })
+})
+
+test.beforeEach(async (t) => {
+  await beforeEach(t)
+})
+
+test.afterEach(async (t) => {
+  await afterEach(t)
+})
+
+test.after.always(async (t) => {
+  await after(t)
+})
+
+test('POST `/package/npm/ownership` 401 unauthorized | middleware', async (t) => {
+  const res = await t.context.app.inject({
+    method: 'POST',
+    url: '/package/npm/ownership',
+    payload: {
+      readOnlyToken: 'blahblahblah'
+    },
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=not_a_gr8_cookie`
+    }
+  })
+  t.deepEqual(res.statusCode, 401)
+})
+
+// tests covering the nuances of db.package.refreshPackages should be in api/package/npm/refresh-ownership
+test('POST `/package/npm/ownership` 200 success', async (t) => {
+  const res = await t.context.app.inject({
+    method: 'POST',
+    url: '/package/npm/ownership',
+    payload: {
+      readOnlyToken: 'blahblahblah'
+    },
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.session}`
+    }
+  })
+  t.deepEqual(res.statusCode, 200)
+
+  const { registry, userId } = t.context
+  const { npm } = registry
+  t.true(npm.getUsername.calledOnce)
+  t.true(npm.getOwnedPackages.calledOnce)
+
+  const packages = await t.context.db.package.getOwnedPackages({ userId, registry: NPM })
+  t.is(packages.length, 2)
+  t.deepEqual(
+    packages.map(({ name, maintainers }) => ({ name, maintainers })),
+    (await npm.getOwnedPackages()).map((pkg) => ({
+      name: pkg,
+      maintainers: [{
+        maintainerId: userId,
+        revenuePercent: 100
+      }]
+    })))
+})
+
+test('POST `/package/npm/ownership` 400 bad request', async (t) => {
+  const res = await t.context.app.inject({
+    method: 'POST',
+    url: '/package/npm/ownership',
+    payload: {},
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.session}`
+    }
+  })
+  t.deepEqual(res.statusCode, 400)
+})
+
+test('POST `/package/npm/ownership` 500 server error', async (t) => {
+  t.context.registry.npm.getUsername = () => { throw new Error('oh no!') }
+  const res = await t.context.app.inject({
+    method: 'POST',
+    url: '/package/npm/ownership',
+    payload: {
+      readOnlyToken: 'blahblahblah'
+    },
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.session}`
+    }
+  })
+  t.deepEqual(res.statusCode, 500)
+})

--- a/test/api/package/npm/ownership.test.js
+++ b/test/api/package/npm/ownership.test.js
@@ -65,7 +65,7 @@ test('POST `/package/npm/ownership` 200 success', async (t) => {
     (await npm.getOwnedPackages()).map((pkg) => ({
       name: pkg,
       maintainers: [{
-        maintainerId: userId,
+        userId,
         revenuePercent: 100
       }]
     })))

--- a/test/registry/npm.test.js
+++ b/test/registry/npm.test.js
@@ -1,17 +1,52 @@
 const test = require('ava')
-const sinon = require('sinon')
-const gop = require('get-owned-packages')
+const nock = require('nock')
 const NpmRegistry = require('../../registry/npm')
 
-test.before(() => {
-  sinon.stub(gop, 'getOwnedPackages').resolves(['js-deep-equals'])
+test.beforeEach((t) => {
+  const reg = new NpmRegistry()
+  t.context.reg = reg
 })
 
-test.after.always(() => {
-  gop.getOwnedPackages.restore()
+test.afterEach((t) => {
+  nock.cleanAll()
 })
 
-test('npm registry | get owned pkgs', async (t) => {
-  const npm = new NpmRegistry()
-  t.deepEqual(await npm.getOwnedPackages(), ['js-deep-equals'])
+// afaik these tests have to be serial since we're mocking API calls
+test.serial('getUsername | calls registry with token', async (t) => {
+  const { reg } = t.context
+
+  const token = 'blahblahblah'
+
+  nock(reg.constants.registry, {
+    reqheaders: {
+      authorization: `Bearer ${token}`
+    }
+  }).get('/-/npm/v1/user')
+    .reply(200, {
+      name: 'twoseventythree'
+    })
+
+  const username = await reg.getUsername({ readOnlyToken: token })
+  t.is(username, 'twoseventythree')
+})
+
+test.serial('getOwnedPackages | returns packages', async (t) => {
+  const { reg } = t.context
+
+  const username = 'twoseventythree'
+
+  nock(reg.constants.registry)
+    .get(`/-/org/${username}/package`)
+    .reply(200, {
+      'js-deep-equals': 'read-write',
+      papajohns: 'read',
+      dominos: 'write'
+    })
+
+  const packages = await reg.getOwnedPackages({ username })
+
+  t.deepEqual(packages, [
+    'js-deep-equals',
+    'dominos'
+  ])
 })


### PR DESCRIPTION
More routes and tests coming; trying to split things up for easier reviews.

design notes: https://www.notion.so/flossbank/Package-Ownership-90979ece48d542d58117bbe081b538db

tested with my own account on staging and looks to have worked:
log msgs:
```
{"msg":"incoming request"}
{"msg":"determining owned packages on NPM for maintainer: 5e9bbff630d05709d05b4d4a"}
{"msg":"5e9bbff630d05709d05b4d4a has username twoseventythree on NPM"}
{"msg":"5e9bbff630d05709d05b4d4a maintains 35 packages on NPM"}
{"msg":"request completed"}
```

db:
![new_ownership_stuff](https://user-images.githubusercontent.com/2707340/104520696-6d392a00-55b0-11eb-9f61-8ed3fcd935f5.png)

i updated the "refresh packages" db method... i think it's right but will be getting it thoroughly unit tested in subsequent PRs