### PR TITLE
Impl delete NPM ownership info

### DIFF
--- a/api/package/npm/delete-ownership.js
+++ b/api/package/npm/delete-ownership.js
@@ -1,0 +1,23 @@
+const { MSGS: { INTERNAL_SERVER_ERROR }, REGISTRIES: { NPM }, LANGUAGES: { JAVASCRIPT } } = require('../../../helpers/constants')
+
+module.exports = async (req, res, ctx) => {
+  try {
+    ctx.log.info('deleting NPM information for: %s', req.session.userId)
+
+    await ctx.db.user.unlinkFromRegistry({ userId: req.session.userId, registry: NPM })
+
+    // effectively tell our DB that this user maintains no packages on NPM
+    await ctx.db.package.refreshOwnership({
+      packages: [],
+      registry: NPM,
+      language: JAVASCRIPT,
+      userId: req.session.userId
+    })
+
+    res.send({ success: true })
+  } catch (e) {
+    ctx.log.error(e)
+    res.status(500)
+    res.send({ success: false, message: INTERNAL_SERVER_ERROR })
+  }
+}

--- a/db/user.js
+++ b/db/user.js
@@ -54,6 +54,18 @@ class UserDbController {
     })
   }
 
+  // unlink registry-specific info from this user account (e.g. username on NPM)
+  async unlinkFromRegistry ({ userId, registry }) {
+    return this.db.collection('users').updateOne({
+      _id: ObjectId(userId)
+    }, {
+      // https://docs.mongodb.com/manual/reference/operator/update/unset/
+      $unset: {
+        [registry]: null
+      }
+    })
+  }
+
   async get ({ userId }) {
     const user = await this.db.collection('users').findOne({ _id: ObjectId(userId) })
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,9 +1,11 @@
 module.exports = {
   REGISTRIES: {
-    NPM: 'npm'
+    NPM: 'npm',
+    RUBYGEMS: 'rubygems'
   },
   LANGUAGES: {
-    JAVASCRIPT: 'javascript'
+    JAVASCRIPT: 'javascript',
+    RUBY: 'ruby'
   },
   MSGS: {
     AD_NOT_CLEAN: 'String must be plain ASCII text. No Unicode, emojis, or control characters allowed.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@flossbank/schema": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@flossbank/schema/-/schema-1.28.0.tgz",
-      "integrity": "sha512-o5Hd+qmGzBPh4UKXsEyHknlY8zodCqT1xuRvfGfhEWnWhdO64jlHu94B02/0agnFx/iW2ndIw4Ky67GCrLSrCw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@flossbank/schema/-/schema-1.29.0.tgz",
+      "integrity": "sha512-5DnoXcy2IYW1xvko0bRbBq7Zb0x+MP0pZdK/IGCTe5itOsnQExL/N5VrCQULjKCmQndsTholHfbWUDGuhgBNwA==",
       "requires": {
         "fluent-schema": "^0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@flossbank/schema": "^1.28.0",
+    "@flossbank/schema": "^1.29.0",
     "@octokit/app": "^4.2.1",
     "ajv": "^6.10.2",
     "aws-sdk": "^2.543.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -74,7 +74,8 @@ const ownedPackages = require('../api/maintainer/owned-packages')
 const searchPackagesByName = require('../api/package/search-by-name')
 const getPackage = require('../api/package/get')
 const npmOwnership = require('../api/package/npm/ownership')
-const refreshNpmOwnership = require('../api/package/npm/refresh-ownership')
+const npmDeleteOwnership = require('../api/package/npm/delete-ownership')
+const npmRefreshOwnership = require('../api/package/npm/refresh-ownership')
 // const updatePackages = require('../api/package/update')
 
 // Session
@@ -180,7 +181,8 @@ async function routes (fastify, opts, done) {
   fastify.get('/package/search', { schema: Schema.package.searchByName }, (req, res) => searchPackagesByName(req, res, fastify))
   fastify.get('/package', { schema: Schema.package.get }, (req, res) => getPackage(req, res, fastify))
   fastify.post('/package/npm/ownership', { schema: Schema.package.npm.ownership, preHandler: (req, res, done) => userWebMiddleware(req, res, fastify, done) }, (req, res) => npmOwnership(req, res, fastify))
-  fastify.put('/package/npm/refresh-ownership', { preHandler: (req, res, done) => userWebMiddleware(req, res, fastify, done), schema: Schema.package.npm.refreshOwnership }, (req, res) => refreshNpmOwnership(req, res, fastify))
+  fastify.delete('/package/npm/ownership', { schema: Schema.package.npm.deleteOwnership, preHandler: (req, res, done) => userWebMiddleware(req, res, fastify, done) }, (req, res) => npmDeleteOwnership(req, res, fastify))
+  fastify.put('/package/npm/refresh-ownership', { preHandler: (req, res, done) => userWebMiddleware(req, res, fastify, done), schema: Schema.package.npm.refreshOwnership }, (req, res) => npmRefreshOwnership(req, res, fastify))
   // fastify.post('/package/update', { preHandler: (req, res, done) => maintainerWebMiddleware(req, res, fastify, done), schema: Schema.package.update }, (req, res) => updatePackages(req, res, fastify))
 
   // Session

--- a/test/api/package/npm/delete-ownership.test.js
+++ b/test/api/package/npm/delete-ownership.test.js
@@ -1,0 +1,118 @@
+const test = require('ava')
+const { before, beforeEach, afterEach, after } = require('../../../_helpers/_setup')
+const { REGISTRIES, LANGUAGES, USER_WEB_SESSION_COOKIE } = require('../../../../helpers/constants')
+
+test.before(async (t) => {
+  await before(t, async ({ db, auth }) => {
+    const email = 'honey@etsy.com'
+    const { id: userId1 } = await db.user.create({ email })
+    t.context.userId1 = userId1.toHexString()
+    const session = await auth.user.createWebSession({ userId: t.context.userId1 })
+    t.context.session = session.sessionId
+
+    const { id: userId2 } = await db.user.create({ email: 'bear@boo.com' })
+    t.context.userId2 = userId2.toHexString()
+
+    // set up the scenario: Honey (user 1) maintains 2 javascript packages, and 1 ruby package
+    // and is about to delete NPM ownership information; she co-maintains one of her
+    // JS packages with Bear (user 2)
+    const { id: yttriumId } = await db.package.create({
+      name: 'yttrium-server',
+      registry: REGISTRIES.NPM,
+      language: LANGUAGES.JAVASCRIPT
+    })
+    await db.package.update({
+      packageId: yttriumId,
+      maintainers: [{ userId: t.context.userId1, revenuePercent: 100 }]
+    })
+    t.context.yttriumId = yttriumId.toHexString()
+
+    const { id: sodium } = await db.package.create({
+      name: 'sodium-native',
+      registry: REGISTRIES.NPM,
+      language: LANGUAGES.JAVASCRIPT
+    })
+    await db.package.update({
+      packageId: sodium,
+      maintainers: [
+        { userId: t.context.userId1, revenuePercent: 30 },
+        { userId: t.context.userId2, revenuePercent: 70 }
+      ]
+    })
+    t.context.sodium = sodium.toHexString()
+
+    const { id: roobs } = await db.package.create({
+      name: 'roobs',
+      registry: REGISTRIES.RUBYGEMS,
+      language: LANGUAGES.RUBY
+    })
+    await db.package.update({
+      packageId: roobs,
+      maintainers: [{ userId: t.context.userId1, revenuePercent: 100 }]
+    })
+    t.context.roobs = roobs.toHexString()
+  })
+})
+
+test.beforeEach(async (t) => {
+  await beforeEach(t)
+})
+
+test.afterEach(async (t) => {
+  await afterEach(t)
+})
+
+test.after.always(async (t) => {
+  await after(t)
+})
+
+test('DELETE `/package/npm/ownership` 401 unauthorized | middleware', async (t) => {
+  const res = await t.context.app.inject({
+    method: 'DELETE',
+    url: '/package/npm/ownership',
+    payload: {},
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=not_a_gr8_cookie`
+    }
+  })
+  t.deepEqual(res.statusCode, 401)
+})
+
+test('DELETE `/package/npm/ownership` 200 success', async (t) => {
+  const { userId1: userId } = t.context
+
+  const res = await t.context.app.inject({
+    method: 'DELETE',
+    url: '/package/npm/ownership',
+    payload: {},
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.session}`
+    }
+  })
+  t.deepEqual(res.statusCode, 200)
+
+  // the db now shows they maintain 0 javascript packages
+  const jsPackages = await t.context.db.package.getOwnedPackages({ userId, registry: REGISTRIES.NPM, language: LANGUAGES.JAVASCRIPT })
+  t.is(jsPackages.length, 0)
+
+  // they still are marked as maintaining the ruby package
+  const rubyPackages = await t.context.db.package.getOwnedPackages({ userId, registry: REGISTRIES.RUBYGEMS, language: LANGUAGES.RUBY })
+  t.is(rubyPackages.length, 1)
+
+  // the package they were co-maintaining is now fully the other person's
+  const sodium = await t.context.db.package.get({ packageId: t.context.sodium })
+  t.deepEqual(sodium.maintainers, [{ userId: t.context.userId2, revenuePercent: 100 }])
+})
+
+test('DELETE `/package/npm/ownership` 500 server error', async (t) => {
+  t.context.db.user.unlinkFromRegistry = () => { throw new Error('oh no!') }
+  const res = await t.context.app.inject({
+    method: 'DELETE',
+    url: '/package/npm/ownership',
+    payload: {},
+    headers: {
+      cookie: `${USER_WEB_SESSION_COOKIE}=${t.context.session}`
+    }
+  })
+  t.deepEqual(res.statusCode, 500)
+})


### PR DESCRIPTION
tested manually with my own account; on a clean db, calling POST /npm/ownership creates 35 new packages with myself as maintainer and adds my NPM username to my profile; calling DELETE /npm/ownership keeps the packages but removes me from the maintainers list, and removes my NPM username from my profile.