### PR TITLE
upgrade efficiency of importing packages

### DIFF
--- a/api/package/npm/delete-ownership.js
+++ b/api/package/npm/delete-ownership.js
@@ -16,6 +16,7 @@ module.exports = async (req, res, ctx) => {
 
     res.send({ success: true })
   } catch (e) {
+    console.log('here', e)
     ctx.log.error(e)
     res.status(500)
     res.send({ success: false, message: INTERNAL_SERVER_ERROR })

--- a/api/package/npm/delete-ownership.js
+++ b/api/package/npm/delete-ownership.js
@@ -16,7 +16,6 @@ module.exports = async (req, res, ctx) => {
 
     res.send({ success: true })
   } catch (e) {
-    console.log('here', e)
     ctx.log.error(e)
     res.status(500)
     res.send({ success: false, message: INTERNAL_SERVER_ERROR })


### PR DESCRIPTION
upgrades efficiency by only updating maintainers.revShare when there is a maintainer to update, instead of doing an entire pkg collection scan each time someone imports a package.